### PR TITLE
Added background-size configuration option

### DIFF
--- a/app/com/gitpitch/models/MarkdownModel.java
+++ b/app/com/gitpitch/models/MarkdownModel.java
@@ -152,7 +152,8 @@ public class MarkdownModel implements Markdown {
                     imageService.extractBgUrl(md, gitRawBase, this);
 
                 return new StringBuffer(delimiter(md))
-                        .append(imageService.buildBackground(pp, imageBgUrl))
+                        .append(imageService.buildBackground(pp, imageBgUrl,
+                                yOpts.fetchImageBgSize(pp)))
                         .toString();
 
             } else if (gistDelimFound(md)) {
@@ -542,7 +543,7 @@ public class MarkdownModel implements Markdown {
     public static final String MD_IFRAME_OPEN =
             "<!-- .slide: data-background-iframe=\"";
     public static final String MD_IMAGE_SIZE =
-            "\" data-background-size=\"100% 100%";
+            "\" data-background-size=\"";
     public static final String MD_CLOSER = "\" -->";
     public static final String MD_SPACER = "\n";
     public static final String DATA_IMAGE_ATTR = "data-background-image=";

--- a/app/com/gitpitch/services/ImageService.java
+++ b/app/com/gitpitch/services/ImageService.java
@@ -43,16 +43,17 @@ public class ImageService {
     public String buildBackground(PitchParams pp,
                                          YAMLOptions yOpts) {
 
-        return buildBackground(pp, yOpts.fetchImageBg(pp));
+        return buildBackground(pp, yOpts.fetchImageBg(pp), yOpts.fetchImageBgSize(pp));
     }
 
     public String buildBackground(PitchParams pp,
-                                         String imageBgUrl) {
+                                         String imageBgUrl, String imageBgSize) {
 
         return new StringBuffer(MarkdownModel.MD_SPACER)
                 .append(MarkdownModel.MD_IMAGE_OPEN)
                 .append(imageBgUrl)
                 .append(MarkdownModel.MD_IMAGE_SIZE)
+                .append(imageBgSize)
                 .append(MarkdownModel.MD_CLOSER)
                 .append(MarkdownModel.MD_SPACER)
                 .toString();
@@ -66,8 +67,8 @@ public class ImageService {
             String fragUrl = frag.substring(0, frag.indexOf("\""));
             String imageName = FilenameUtils.getName(fragUrl);
             String imageUrl = IMG_OFFLINE_DIR + imageName;
-            return buildBackground(null, imageUrl);
 
+            return md.replace(fragUrl, imageUrl);
         } catch (Exception bex) {
         }
 

--- a/app/com/gitpitch/utils/YAMLOptions.java
+++ b/app/com/gitpitch/utils/YAMLOptions.java
@@ -164,6 +164,16 @@ public final class YAMLOptions {
         }
     }
 
+    public String fetchImageBgSize(PitchParams pp) {
+        String bgSize = _yProps.get(IMAGE_BG_SIZE_OPTION);
+        if (bgSize == null) {
+            return DEFAULT_BG_SIZE;
+        } else {
+            return bgSize;
+        }
+    }
+
+
     public String fetchTransition(PitchParams pp) {
 
         String transition = _yProps.get(TRANSITION_OPTION);
@@ -316,6 +326,7 @@ public final class YAMLOptions {
     }
 
     public static final String PITCHME_YAML = "PITCHME.yaml";
+    public static final String DEFAULT_BG_SIZE = "100% 100%";
     public static final String DEFAULT_TRANSITION = "slide";
     public static final String MATHJAX_DEFAULT = "TeX-MML-AM_CHTML";
     public static final String HIGHLIGHT_DARK_DEFAULT = "github-gist.css";
@@ -328,6 +339,7 @@ public final class YAMLOptions {
     private static final String VERTICAL_CENTER = "vertical-center";
     private static final String LOGO_OPTION = "logo";
     private static final String IMAGE_BG_OPTION = "background";
+    private static final String IMAGE_BG_SIZE_OPTION = "background-size";
     private static final String TRANSITION_OPTION = "transition";
     private static final String AUTOSLIDE_OPTION = "autoslide";
     private static final String LOOP_OPTION = "loop";


### PR DESCRIPTION
This adds a configuration option to `PITCHME.yaml` called `background-size` that allows you to set the reveal.js `data-background-size` attribute.  It defaults to `100% 100%` so this won't have any impact on existing presentations, but allows for example you to select `cover`, where you don't want the image dimensions to be distorted due to screen size.

I wasn't able to test the offline image processing for this, since it seems that offline background images don't work.