### PR TITLE
Add LauncherJarPlugin option to avoid long APP_CLASSPATH line.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := """server"""
 version := "1.1"
 organization := "com.gitpitch"
 
-lazy val root = (project in file(".")).enablePlugins(PlayJava)
+lazy val root = (project in file(".")).enablePlugins(PlayJava, LauncherJarPlugin)
 
 scalaVersion := "2.11.11"
 


### PR DESCRIPTION
In Windows,  when running server.bat I get following message

```
The input line is too long.
The syntax of the command is incorrect.
```

This is because Windows has limit of arround 8000 chars in one line. `bin/server.bat` has more long line for APP_CLASSPATH.

In [this page](https://stackoverflow.com/questions/21429234/play-framework-2-stage-task-on-windows-the-input-line-is-too-long) shows same problem and provides solution.

This PR avoids `APP_CLASSPATH` problem by add `LauncherJarPlugin` option to sbt `PlayScala` plugin.