### PR TITLE
try to improve decktape integration/setup

### DIFF
--- a/app/com/gitpitch/services/PrintService.java
+++ b/app/com/gitpitch/services/PrintService.java
@@ -166,7 +166,7 @@ public class PrintService {
                         .absoluteURL(isEncrypted(),
                                 hostname());
 
-        String[] cmd = {PDF_PHANTOM,
+        String[] cmd = {
                 PDF_DECKTAPE,
                 PDF_COMMAND,
                 slideshowUrl,
@@ -190,8 +190,7 @@ public class PrintService {
         return configuration.getString("gitpitch.hostname");
     }
 
-    private static final String PDF_PHANTOM = "./bin/phantomjs";
-    private static final String PDF_DECKTAPE = "decktape.js";
+    private static final String PDF_DECKTAPE = "decktape";
     private static final String PDF_COMMAND = "reveal";
     private static final String PITCHME_PDF = "PITCHME.pdf";
     private static final String PRINT_NO_FRAGS = "false";

--- a/app/com/gitpitch/services/ShellService.java
+++ b/app/com/gitpitch/services/ShellService.java
@@ -51,8 +51,8 @@ public class ShellService {
                     .start();
 
             resp = cmdProc.waitFor();
-            log.debug("exec: op={}, pp={}, time taken={}", op, pp,
-                    (System.currentTimeMillis() - startProc));
+            log.debug("exec: op={}, pp={}, time taken={}, cmd={}", op, pp,
+                    (System.currentTimeMillis() - startProc), cmd);
 
 
         } catch (IOException ioex) {

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "decktape": "^2.3.0",
+    "phantomjs": "^2.1.7"
+  }
+}


### PR DESCRIPTION
the documentation about getting a working PrintService is a little lacking. and potentially also PrintService is with it's shelling out. Idk, but i couldn't figure out what weird crazy way it was expecting to find everything so I tweaked it a bit and added a `package.json` so after you unpack the dist zip you can `npm i` or `yarn install` and use decktape `home = "node_modules/.bin"` in the config. the versions in the `package.json` can be tweaked as needed.
seems to work for me on OSX, but idk how you'd want it tested.