### PR TITLE
Add the ability to accept comma delimited fonts

### DIFF
--- a/app/com/gitpitch/services/ShortcutsService.java
+++ b/app/com/gitpitch/services/ShortcutsService.java
@@ -242,12 +242,15 @@ public class ShortcutsService {
      */
     private String buildFontAwesome(String font, String text) {
         if(text == null) text = "";
-        return new StringBuffer(HTML_FONT_FRAG_OPEN)
-                .append(font)
-                .append(HTML_FONT_FRAG_CLOSE)
-                .append(text)
-                .append(HTML_FONT_FRAG_TEXT_CLOSE)
-                .toString();
+        StringBuffer buffer = new StringBuffer(HTML_FONT_FRAG_OPEN);
+        for (String f: font.split(",")){
+            buffer.append(HTML_FONT_FRAG_INTERMEDIATE)
+                  .append(f);
+        }        
+        return buffer.append(HTML_FONT_FRAG_CLOSE)
+                     .append(text)
+                     .append(HTML_FONT_FRAG_TEXT_CLOSE)
+                     .toString();
     }
 
     /*
@@ -264,7 +267,8 @@ public class ShortcutsService {
     private static final String TITLE_HINT_SPAN_OPEN =
         "<span class=\"menu-title\" style=\"display: none\">";
     private static final String TITLE_HINT_SPAN_CLOSE = "</span>";
-    private static final String HTML_FONT_FRAG_OPEN = "<i class=\"fa fa-";
+    private static final String HTML_FONT_FRAG_OPEN = "<i class=\"fa ";
+    private static final String HTML_FONT_FRAG_INTERMEDIATE "fa-";
     private static final String HTML_FONT_FRAG_CLOSE = "\" aria-hidden=\"true\"> ";
     private static final String HTML_FONT_FRAG_TEXT_CLOSE = "</i>";
 

--- a/app/com/gitpitch/services/ShortcutsService.java
+++ b/app/com/gitpitch/services/ShortcutsService.java
@@ -267,8 +267,8 @@ public class ShortcutsService {
     private static final String TITLE_HINT_SPAN_OPEN =
         "<span class=\"menu-title\" style=\"display: none\">";
     private static final String TITLE_HINT_SPAN_CLOSE = "</span>";
-    private static final String HTML_FONT_FRAG_OPEN = "<i class=\"fa ";
-    private static final String HTML_FONT_FRAG_INTERMEDIATE "fa-";
+    private static final String HTML_FONT_FRAG_OPEN = "<i class=\"fa";
+    private static final String HTML_FONT_FRAG_INTERMEDIATE " fa-";
     private static final String HTML_FONT_FRAG_CLOSE = "\" aria-hidden=\"true\"> ";
     private static final String HTML_FONT_FRAG_TEXT_CLOSE = "</i>";
 


### PR DESCRIPTION
I would like the ability to write markup for font-awesome that allows multiple font classes for a single shortcut expression. See [animated icons](https://fontawesome.com/v4.7.0/examples/) for inspiration.

For example:
```
@fa[refresh,spin]
```
This would render the following:
```html
<i class="fa fa-refresh fa-spin" aria-hidden="true"></i>
```